### PR TITLE
Various Spark compatibility issues

### DIFF
--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -34,7 +34,7 @@ renamed as (
         context_campaign_name as utm_campaign,
         context_campaign_term as utm_term,
         context_campaign_content as utm_content,
-        {{ dbt_utils.get_url_parameter('url', 'gclid') }} as gclid,
+        split(split(parse_url(url,'QUERY'),'gclid=')[1],'&')[0] as gclid,
         context_ip as ip,
         context_user_agent as user_agent,
         case

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -22,7 +22,7 @@ with pageviews as (
     where anonymous_id in (
         select distinct anonymous_id
         from {{ref('segment_web_page_views')}}
-        where cast(tstamp as datetime) >= (
+        where cast(tstamp as timestamp) >= (
           select
             {{ dbt_utils.dateadd(
                 'hour',

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -47,7 +47,7 @@ with pageviews_sessionized as (
     select * from {{ref('segment_web_page_views__sessionized')}}
 
     {% if is_incremental() %}
-        where cast(tstamp as datetime) > (
+        where cast(tstamp as timestamp) > (
           select
             {{ dbt_utils.dateadd(
                 'hour',

--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -11,7 +11,7 @@ with sessions as (
     select * from {{ref('segment_web_sessions__initial')}}
 
     {% if is_incremental() %}
-        where cast(session_start_tstamp as datetime) > (
+        where cast(session_start_tstamp as timestamp) > (
           select
             {{ dbt_utils.dateadd(
                 'hour',


### PR DESCRIPTION
## Description & motivation
The Fishtown Segment plugin is useful but not compatible with Spark. Changes made:
* Replaced `get_url_parameter` with native SQL as it appears broken on Spark
* Replaced all `datetime` with `timestamps` as Spark does not support `datetime`
* Spark does not support `ignore nulls` in a window function, so created an intermediate CTE which excludes nulls

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
