### PR TITLE
Remove duplicates in segment_web_page_views__sessionized

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -126,7 +126,7 @@ session_ids as (
     --This CTE assigns a globally unique session id based on the combination of
     --`anonymous_id` and `session_number`.
 
-    select
+    select distinct
 
         {{dbt_utils.star(ref('segment_web_page_views'))}},
         page_view_number,


### PR DESCRIPTION
## Description & motivation

Tests are failing because this model is generating duplicates. The row is not duplicated in the upstream model:

```
1029 of 1034 FAIL 1 unique_segment_web_page_views__sessionized_page_view_id [\x1b[31mFAIL 1\x1b[0m in 10.01s]\n'
...
Failure in test unique_segment_web_page_views__sessionized_page_view_id (models/sessionization/schema.yml)
Got 1 result, expected 0
compiled SQL at target/compiled/segment/models/sessionization/schema.yml/schema_test/unique_segment_web_page_views__sessionized_page_view_id.sql
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

## Post-merge checklist
- [x] `dbt run --target prod --full-refresh -m segment_web_page_views__sessionized`

## Local run
```
dbt run -m +segment_web_page_views__sessionized
Running with dbt=0.19.0
Found 390 models, 1035 tests, 9 snapshots, 2 analyses, 411 macros, 1 operation, 14 seed files, 196 sources, 22 exposures

10:15:08 |
10:15:08 | Running 1 on-run-start hook
10:15:09 | 1 of 1 START hook: dbt_databricks.on-run-start.0..................... [RUN]
10:15:09 | 1 of 1 OK hook: dbt_databricks.on-run-start.0........................ [OK in 0.00s]
10:15:09 |
10:15:09 | Concurrency: 5 threads (target='dev')
10:15:09 |
10:15:09 | 1 of 8 START view model fran_dev_stg.stg_segment_client_events....... [RUN]
10:15:09 | 2 of 8 START view model fran_dev_stg.stg_segment_marketing_site_events [RUN]
10:15:13 | 2 of 8 OK created view model fran_dev_stg.stg_segment_marketing_site_events [OK in 3.98s]
10:15:13 | 3 of 8 START view model fran_dev_stg.stg_segment_marketing_site_pages [RUN]
10:15:13 | 1 of 8 OK created view model fran_dev_stg.stg_segment_client_events.. [OK in 4.02s]
10:15:13 | 4 of 8 START view model fran_dev_stg.stg_segment_client_pages........ [RUN]
10:15:20 | 3 of 8 OK created view model fran_dev_stg.stg_segment_marketing_site_pages [OK in 7.00s]
10:15:20 | 4 of 8 OK created view model fran_dev_stg.stg_segment_client_pages... [OK in 7.13s]
10:15:20 | 5 of 8 START view model fran_dev_stg.stg_segment_all_pages........... [RUN]
10:15:34 | 5 of 8 OK created view model fran_dev_stg.stg_segment_all_pages...... [OK in 14.16s]
10:15:34 | 6 of 8 START view model fran_dev_stg.stg_segment_pages_pre_stitch.... [RUN]
10:15:44 | 6 of 8 OK created view model fran_dev_stg.stg_segment_pages_pre_stitch [OK in 10.51s]
10:15:44 | 7 of 8 START view model fran_dev.segment_web_page_views.............. [RUN]
10:15:49 | 7 of 8 OK created view model fran_dev.segment_web_page_views......... [OK in 4.49s]
10:15:49 | 8 of 8 START incremental model fran_dev.segment_web_page_views__sessionized [RUN]
10:24:40 | 8 of 8 OK created incremental model fran_dev.segment_web_page_views__sessionized [OK in 531.02s]
10:24:42 |
10:24:42 | Finished running 7 view models, 1 incremental model, 1 hook in 604.17s.

Completed successfully

Done. PASS=8 WARN=0 ERROR=0 SKIP=0 TOTAL=8
```
```
dbt run -m segment_web_page_views__sessionized
Running with dbt=0.19.0
Found 390 models, 1035 tests, 9 snapshots, 2 analyses, 411 macros, 1 operation, 14 seed files, 196 sources, 22 exposures

10:26:31 |
10:26:31 | Running 1 on-run-start hook
10:26:31 | 1 of 1 START hook: dbt_databricks.on-run-start.0..................... [RUN]
10:26:31 | 1 of 1 OK hook: dbt_databricks.on-run-start.0........................ [OK in 0.00s]
10:26:31 |
10:26:31 | Concurrency: 5 threads (target='dev')
10:26:31 |
10:26:31 | 1 of 1 START incremental model fran_dev.segment_web_page_views__sessionized [RUN]
10:41:02 | 1 of 1 OK created incremental model fran_dev.segment_web_page_views__sessionized [OK in 871.39s]
10:41:04 |
10:41:04 | Finished running 1 incremental model, 1 hook in 887.96s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
```
dbt test -m segment_web_page_views__sessionized
Running with dbt=0.19.0
Found 390 models, 1035 tests, 9 snapshots, 2 analyses, 411 macros, 1 operation, 14 seed files, 196 sources, 22 exposures

10:44:18 | Concurrency: 5 threads (target='dev')
10:44:18 |
10:44:18 | 1 of 2 START test not_null_segment_web_page_views__sessionized_page_view_id [RUN]
10:44:18 | 2 of 2 START test unique_segment_web_page_views__sessionized_page_view_id [RUN]
10:44:25 | 1 of 2 PASS not_null_segment_web_page_views__sessionized_page_view_id [PASS in 7.49s]
10:44:26 | 2 of 2 PASS unique_segment_web_page_views__sessionized_page_view_id.. [PASS in 7.98s]
10:44:26 |
10:44:26 | Finished running 2 tests in 16.75s.

Completed successfully

Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```